### PR TITLE
Add HTTPS `rejectUnauthorized` option

### DIFF
--- a/packages/axis-core/README.md
+++ b/packages/axis-core/README.md
@@ -101,6 +101,12 @@ interface Options {
      * The HTTP or HTTPS agent used when opening the connection.
      */
     agent?: http.Agent | https.Agent;
+
+    /**
+     * Whether to reject invalid HTTPS certificates, e.g., expired or
+     * self-signed. Defaults to `true`.
+     */
+    rejectUnauthorized?: boolean;
 }
 ```
 

--- a/packages/axis-core/src/Connection.ts
+++ b/packages/axis-core/src/Connection.ts
@@ -10,6 +10,11 @@ export interface Options {
      * The HTTP or HTTPS agent used when opening the connection.
      */
     agent?: http.Agent | https.Agent;
+    /**
+     * Whether to reject invalid HTTPS certificates, e.g., expired or
+     * self-signed. Defaults to `true`.
+     */
+    rejectUnauthorized?: boolean;
 }
 
 /**

--- a/packages/axis-core/src/auth/client-provider.ts
+++ b/packages/axis-core/src/auth/client-provider.ts
@@ -1,13 +1,17 @@
 import got, { Agents, Got } from 'got';
 import * as http from 'http';
 import * as https from 'https';
+import { Options } from '../Connection';
 import * as basic from './basic';
 import { parse } from './challenge';
 import * as digest from './digest';
 
-export const clientProvider = (method: string, url: string, username: string, password: string, agent?: http.Agent | https.Agent): Got => {
+export const clientProvider = (method: string, url: string, username: string, password: string, options?: Options): Got => {
     return got.extend({
-        agent: createAgent(agent),
+        agent: createAgent(options?.agent),
+        https: {
+            rejectUnauthorized: options?.rejectUnauthorized ?? true,
+        },
         hooks: {
             afterResponse: [
                 (res, retryWithMergedOptions) => {

--- a/packages/axis-core/src/client.ts
+++ b/packages/axis-core/src/client.ts
@@ -9,7 +9,7 @@ import { Response } from './Response';
  */
 export const get = (connection: Connection, relativePath: string): Promise<Response> => {
     const url = connection.url + format(relativePath);
-    return clientProvider('GET', url, connection.username, connection.password, connection?.options?.agent).get<Buffer>(url);
+    return clientProvider('GET', url, connection.username, connection.password, connection.options).get<Buffer>(url);
 };
 
 const format = (relativePath: string): string => {

--- a/packages/axis-core/test/Connection.spec.ts
+++ b/packages/axis-core/test/Connection.spec.ts
@@ -33,5 +33,16 @@ describe('connection', () => {
             expect(got).toBeTruthy();
             expect(got.options?.agent).toBeTruthy();
         });
+
+        test('should return connection with https reject unauthorized options', () => {
+            // Act
+            const got = new Connection(Protocol.Http, '1.2.3.4', 80, 'root', 'pass', {
+                rejectUnauthorized: true,
+            });
+
+            // Assert
+            expect(got).toBeTruthy();
+            expect(got.options?.rejectUnauthorized).toBe(true);
+        });
     });
 });

--- a/packages/axis-core/test/auth/client-provider.spec.ts
+++ b/packages/axis-core/test/auth/client-provider.spec.ts
@@ -8,7 +8,7 @@ describe('#clientProvider should', () => {
         const agent = new http.Agent({ keepAlive: true });
 
         // Act
-        const got = clientProvider('GET', 'https://github.com/FantasticFiasco/axis-js', '', '', agent);
+        const got = clientProvider('GET', 'https://github.com/FantasticFiasco/axis-js', '', '', { agent });
 
         // Assert
         expect((got.defaults.options.agent as { http: http.Agent }).http).toBe(agent);
@@ -19,9 +19,25 @@ describe('#clientProvider should', () => {
         const agent = new https.Agent({ keepAlive: true });
 
         // Act
-        const got = clientProvider('GET', 'https://github.com/FantasticFiasco/axis-js', '', '', agent);
+        const got = clientProvider('GET', 'https://github.com/FantasticFiasco/axis-js', '', '', { agent });
 
         // Assert
         expect((got.defaults.options.agent as { https: https.Agent }).https).toBe(agent);
+    });
+
+    test('respect https reject unauthorized disabled', () => {
+        // Act
+        const got = clientProvider('GET', 'https://github.com/FantasticFiasco/axis-js', '', '', { rejectUnauthorized: false });
+
+        // Assert
+        expect(got.defaults.options.https?.rejectUnauthorized).toBe(false);
+    });
+
+    test('default https reject unauthorized to enabled', () => {
+        // Act
+        const got = clientProvider('GET', 'https://github.com/FantasticFiasco/axis-js', '', '');
+
+        // Assert
+        expect(got.defaults.options.https?.rejectUnauthorized).toBe(true);
     });
 });


### PR DESCRIPTION
# Description

This allows for connecting to cameras with self-signed certificates over HTTPS.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works